### PR TITLE
Bump `proc-macro-crate` to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "expander"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +95,7 @@ version = "0.0.7"
 dependencies = [
  "assert_matches",
  "expander",
- "indexmap",
+ "indexmap 1.8.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -126,13 +132,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -151,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,12 +186,11 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -277,6 +304,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.6",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,3 +382,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,6 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
-dependencies = [
- "serde_derive",
-]
 
 [[package]]
 name = "serde_derive"
@@ -322,13 +319,14 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.55"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a24e67e2b4083a6d0beb5a98e274c3160edfb879d71cd2cd14da93786a93b"
+checksum = "e7f408301c7480f9e6294eb779cfc907f54bd901a9660ef24d7f233ed5376485"
 dependencies = [
  "glob",
  "once_cell",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro2 = "1.0.32"
 quote = "1.0.10"
 syn = { version = "1.0.82", features = ["full", "extra-traits"], default-features = false }
 thiserror = "1.0.30"
-proc-macro-crate = "1.1.0"
+proc-macro-crate = "3.1.0"
 indexmap = "1.7.0"
 expander = "0.0.6"
 

--- a/proc-macro/src/types.rs
+++ b/proc-macro/src/types.rs
@@ -164,7 +164,7 @@ fn trait_fatality_impl_for_struct(who: &Ident, resolution: &ResolutionMode) -> T
 }
 
 #[derive(Debug, Clone)]
-struct Transparent(kw::transparent);
+struct Transparent;
 
 impl Parse for Transparent {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -174,7 +174,8 @@ impl Parse for Transparent {
         let lookahead = content.lookahead1();
 
         if lookahead.peek(kw::transparent) {
-            Ok(Self(content.parse::<kw::transparent>()?))
+            content.parse::<kw::transparent>()?;
+            Ok(Self)
         } else {
             Err(lookahead.error())
         }

--- a/proc-macro/src/types.rs
+++ b/proc-macro/src/types.rs
@@ -164,7 +164,8 @@ fn trait_fatality_impl_for_struct(who: &Ident, resolution: &ResolutionMode) -> T
 }
 
 #[derive(Debug, Clone)]
-struct Transparent;
+#[allow(dead_code)]
+struct Transparent(kw::transparent);
 
 impl Parse for Transparent {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -174,8 +175,7 @@ impl Parse for Transparent {
         let lookahead = content.lookahead1();
 
         if lookahead.peek(kw::transparent) {
-            content.parse::<kw::transparent>()?;
-            Ok(Self)
+            Ok(Self(content.parse::<kw::transparent>()?))
         } else {
             Err(lookahead.error())
         }

--- a/tests/ui/err-01.stderr
+++ b/tests/ui/err-01.stderr
@@ -1,5 +1,3 @@
-warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
-note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-01.rs:39:12
    |

--- a/tests/ui/err-01.stderr
+++ b/tests/ui/err-01.stderr
@@ -1,12 +1,16 @@
+warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
+note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-01.rs:39:12
    |
 38 | fn iffy() -> Result<(), Kaboom> {
    |              ------------------ expected `Kaboom` because of this
 39 |     Err(Fatal)?
-   |               ^ the trait `From<Fatal>` is not implemented for `Kaboom`
+   |     ----------^ the trait `From<Fatal>` is not implemented for `Kaboom`, which is required by `Result<(), Kaboom>: FromResidual<Result<Infallible, Fatal>>`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Fatal>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following implementations were found:
-             <Kaboom as From<Bobo>>
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Fatal>>` for `Result<(), Kaboom>`
+   = help: the trait `From<Bobo>` is implemented for `Kaboom`
+   = help: for that trait implementation, expected `Bobo`, found `Fatal`
+   = note: required for `Result<(), Kaboom>` to implement `FromResidual<Result<Infallible, Fatal>>`

--- a/tests/ui/err-02.stderr
+++ b/tests/ui/err-02.stderr
@@ -1,5 +1,3 @@
-warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
-note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
   --> tests/ui/err-02.rs:34:1
    |

--- a/tests/ui/err-02.stderr
+++ b/tests/ui/err-02.stderr
@@ -1,13 +1,29 @@
+warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
+note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
+  --> tests/ui/err-02.rs:34:1
+   |
+34 | #[fatality]
+   | ^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
+   |
+   = help: the trait `Fatality` is implemented for `Kaboom`
+   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-02.rs:45:12
    |
 44 | fn iffy() -> Result<(), Kaboom> {
    |              ------------------ expected `Kaboom` because of this
 45 |     Err(Fatal)?
-   |               ^ the trait `From<Fatal>` is not implemented for `Kaboom`
+   |     ----------^ the trait `From<Fatal>` is not implemented for `Kaboom`, which is required by `Result<(), Kaboom>: FromResidual<Result<Infallible, Fatal>>`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Fatal>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Fatal>>` for `Result<(), Kaboom>`
+   = help: the following other types implement trait `FromResidual<R>`:
+             <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
+   = note: required for `Result<(), Kaboom>` to implement `FromResidual<Result<Infallible, Fatal>>`
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-02.rs:49:11
@@ -15,15 +31,12 @@ error[E0277]: `?` couldn't convert the error to `Kaboom`
 48 | fn bobo() -> Result<(), Kaboom> {
    |              ------------------ expected `Kaboom` because of this
 49 |     Err(Bobo)?
-   |              ^ the trait `From<Bobo>` is not implemented for `Kaboom`
+   |     ---------^ the trait `From<Bobo>` is not implemented for `Kaboom`, which is required by `Result<(), Kaboom>: FromResidual<Result<Infallible, Bobo>>`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Bobo>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Bobo>>` for `Result<(), Kaboom>`
-
-error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
-  --> tests/ui/err-02.rs:34:1
-   |
-34 | #[fatality]
-   | ^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
-   |
-   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: the following other types implement trait `FromResidual<R>`:
+             <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
+   = note: required for `Result<(), Kaboom>` to implement `FromResidual<Result<Infallible, Bobo>>`

--- a/tests/ui/err-03.stderr
+++ b/tests/ui/err-03.stderr
@@ -1,5 +1,12 @@
-warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
-note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
+  --> tests/ui/err-03.rs:34:1
+   |
+34 | #[fatality(splitable)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
+   |
+   = help: the trait `Fatality` is implemented for `Kaboom`
+   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
   --> tests/ui/err-03.rs:34:1
    |

--- a/tests/ui/err-03.stderr
+++ b/tests/ui/err-03.stderr
@@ -1,16 +1,29 @@
+warning: `$DIR/target/tests/fatality/.cargo/config` is deprecated in favor of `config.toml`
+note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
+  --> tests/ui/err-03.rs:34:1
+   |
+34 | #[fatality(splitable)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
+   |
+   = help: the trait `Fatality` is implemented for `Kaboom`
+   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-03.rs:45:12
    |
 44 | fn iffy() -> Result<(), Kaboom> {
    |              ------------------ expected `Kaboom` because of this
 45 |     Err(Fatal)?
-   |               ^ the trait `From<Fatal>` is not implemented for `Kaboom`
+   |     ----------^ the trait `From<Fatal>` is not implemented for `Kaboom`, which is required by `Result<(), Kaboom>: FromResidual<Result<Infallible, Fatal>>`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Fatal>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following implementations were found:
+   = help: the following other types implement trait `From<T>`:
              <Kaboom as From<FatalKaboom>>
              <Kaboom as From<JfyiKaboom>>
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Fatal>>` for `Result<(), Kaboom>`
+   = note: required for `Result<(), Kaboom>` to implement `FromResidual<Result<Infallible, Fatal>>`
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-03.rs:49:11
@@ -18,18 +31,12 @@ error[E0277]: `?` couldn't convert the error to `Kaboom`
 48 | fn bobo() -> Result<(), Kaboom> {
    |              ------------------ expected `Kaboom` because of this
 49 |     Err(Bobo)?
-   |              ^ the trait `From<Bobo>` is not implemented for `Kaboom`
+   |     ---------^ the trait `From<Bobo>` is not implemented for `Kaboom`, which is required by `Result<(), Kaboom>: FromResidual<Result<Infallible, Bobo>>`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Bobo>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following implementations were found:
+   = help: the following other types implement trait `From<T>`:
              <Kaboom as From<FatalKaboom>>
              <Kaboom as From<JfyiKaboom>>
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Bobo>>` for `Result<(), Kaboom>`
-
-error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
-  --> tests/ui/err-03.rs:34:1
-   |
-34 | #[fatality(splitable)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
-   |
-   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required for `Result<(), Kaboom>` to implement `FromResidual<Result<Infallible, Bobo>>`


### PR DESCRIPTION
Hey @drahnr. Long time no see :)

I'm trying to get [this fix for proc-macro-crate](https://github.com/bkchr/proc-macro-crate/issues/48) fixed in a project (polkadot-sdk) where fatality is a dependency. For this reason I'm tracking all crates depending on proc-macro-create and bumping the versions. Fatality is one such project.

Do you see a problem with using the latest proc-macro-crate in fatality?