### PR TITLE
Fixes for Edition 2024

### DIFF
--- a/proc-macro/src/types.rs
+++ b/proc-macro/src/types.rs
@@ -41,8 +41,8 @@ impl std::fmt::Debug for ResolutionMode {
         match self {
             Self::NoAnnotation => writeln!(f, "None"),
             Self::Fatal => writeln!(f, "Fatal"),
-            Self::WithExplicitBool(ref b) => writeln!(f, "Fatal({})", b.value()),
-            Self::Forward(_, ref member) => writeln!(
+            Self::WithExplicitBool(b) => writeln!(f, "Fatal({})", b.value()),
+            Self::Forward(_, member) => writeln!(
                 f,
                 "Fatal(Forward, {})",
                 member
@@ -259,7 +259,7 @@ fn to_pattern(
     let from = Ident::new("from", span);
 
     let (pat, resolution) = match fields {
-        Fields::Named(ref fields) => {
+        Fields::Named(fields) => {
             let (fields, resolution) = match requested_resolution_mode {
                 ResolutionMode::Forward(fwd, _ident) => {
                     let fwd_field = if is_transparent {
@@ -271,7 +271,16 @@ fn to_pattern(
                                 .iter()
                                 .find(|attr| attr.path().is_ident(&source) || attr.path().is_ident(&from))
                                 .is_some()
-                        }).ok_or_else(|| syn::Error::new(
+                        })
+                        .or_else(|| {
+                            fields.named.iter().find(|field| {
+                                field
+                                    .ident
+                                    .as_ref()
+                                    .is_some_and(|field_ident| field_ident == "source")
+                            })
+                        })
+                        .ok_or_else(|| syn::Error::new(
                             fields.span(),
                             "No field annotated with `#[source]` or `#[from]`, but requires one for `#[fatal(forward)]`.")
                         )?
@@ -290,7 +299,7 @@ fn to_pattern(
                         colon_token: None,
                         pat: Box::new(Pat::Ident(PatIdent {
                             attrs: vec![],
-                            by_ref: Some(Token![ref](span)),
+                            by_ref: None,
                             mutability: None,
                             ident: field_name.clone(),
                             subpat: None,
@@ -322,7 +331,7 @@ fn to_pattern(
                 resolution,
             )
         }
-        Fields::Unnamed(ref fields) => {
+        Fields::Unnamed(fields) => {
             let (mut field_pats, resolution) = if let ResolutionMode::Forward(keyword, _) =
                 requested_resolution_mode
             {
@@ -372,7 +381,7 @@ fn to_pattern(
 
                 field_pats.push(Pat::Ident(PatIdent {
                     attrs: vec![],
-                    by_ref: Some(Token![ref](span)),
+                    by_ref: None,
                     mutability: None,
                     ident: pat_capture_ident.clone(),
                     subpat: None,

--- a/tests/ui/err-01.stderr
+++ b/tests/ui/err-01.stderr
@@ -13,12 +13,12 @@ note: `Kaboom` needs to implement `From<Fatal>`
    |
 29 | enum Kaboom {
    | ^^^^^^^^^^^
-note: alternatively, `Fatal` needs to implement `Into<Kaboom>`
-  --> tests/ui/err-01.rs:22:1
-   |
-22 | struct Fatal;
-   | ^^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the trait `From<Fatal>` is not implemented for `Kaboom`
-           but trait `From<Bobo>` is implemented for it
+help: the trait `From<Fatal>` is not implemented for `Kaboom`
+      but trait `From<Bobo>` is implemented for it
+  --> tests/ui/err-01.rs:28:1
+   |
+28 | #[fatality]
+   | ^^^^^^^^^^^
    = help: for that trait implementation, expected `Bobo`, found `Fatal`
+   = note: this error originates in the derive macro `::fatality::thiserror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/err-02.stderr
+++ b/tests/ui/err-02.stderr
@@ -2,9 +2,18 @@ error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
   --> tests/ui/err-02.rs:34:1
    |
 34 | #[fatality]
-   | ^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
+   | ^^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Fatality` is implemented for `Kaboom`
+help: the trait `Fatality` is not implemented for `Fatal`
+  --> tests/ui/err-02.rs:22:1
+   |
+22 | struct Fatal;
+   | ^^^^^^^^^^^^
+help: the trait `Fatality` is implemented for `Kaboom`
+  --> tests/ui/err-02.rs:34:1
+   |
+34 | #[fatality]
+   | ^^^^^^^^^^^
    = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
@@ -22,11 +31,6 @@ note: `Kaboom` needs to implement `From<Fatal>`
    |
 35 | enum Kaboom {
    | ^^^^^^^^^^^
-note: alternatively, `Fatal` needs to implement `Into<Kaboom>`
-  --> tests/ui/err-02.rs:22:1
-   |
-22 | struct Fatal;
-   | ^^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
@@ -43,10 +47,5 @@ note: `Kaboom` needs to implement `From<Bobo>`
   --> tests/ui/err-02.rs:35:1
    |
 35 | enum Kaboom {
-   | ^^^^^^^^^^^
-note: alternatively, `Bobo` needs to implement `Into<Kaboom>`
-  --> tests/ui/err-02.rs:32:1
-   |
-32 | struct Bobo;
    | ^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait

--- a/tests/ui/err-03.stderr
+++ b/tests/ui/err-03.stderr
@@ -2,9 +2,18 @@ error[E0277]: the trait bound `Fatal: Fatality` is not satisfied
   --> tests/ui/err-03.rs:34:1
    |
 34 | #[fatality(splitable)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `Fatality` is not implemented for `Fatal`
+   | ^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Fatality` is implemented for `Kaboom`
+help: the trait `Fatality` is not implemented for `Fatal`
+  --> tests/ui/err-03.rs:22:1
+   |
+22 | struct Fatal;
+   | ^^^^^^^^^^^^
+help: the trait `Fatality` is implemented for `Kaboom`
+  --> tests/ui/err-03.rs:34:1
+   |
+34 | #[fatality(splitable)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
@@ -22,15 +31,16 @@ note: `Kaboom` needs to implement `From<Fatal>`
    |
 35 | enum Kaboom {
    | ^^^^^^^^^^^
-note: alternatively, `Fatal` needs to implement `Into<Kaboom>`
-  --> tests/ui/err-03.rs:22:1
-   |
-22 | struct Fatal;
-   | ^^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `Kaboom` implements `From<FatalKaboom>`
-             `Kaboom` implements `From<JfyiKaboom>`
+help: the following other types implement trait `From<T>`
+  --> tests/ui/err-03.rs:34:1
+   |
+34 | #[fatality(splitable)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `Kaboom` implements `From<FatalKaboom>`
+   | `Kaboom` implements `From<JfyiKaboom>`
+   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `?` couldn't convert the error to `Kaboom`
   --> tests/ui/err-03.rs:49:11
@@ -47,12 +57,13 @@ note: `Kaboom` needs to implement `From<Bobo>`
    |
 35 | enum Kaboom {
    | ^^^^^^^^^^^
-note: alternatively, `Bobo` needs to implement `Into<Kaboom>`
-  --> tests/ui/err-03.rs:32:1
-   |
-32 | struct Bobo;
-   | ^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `Kaboom` implements `From<FatalKaboom>`
-             `Kaboom` implements `From<JfyiKaboom>`
+help: the following other types implement trait `From<T>`
+  --> tests/ui/err-03.rs:34:1
+   |
+34 | #[fatality(splitable)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `Kaboom` implements `From<FatalKaboom>`
+   | `Kaboom` implements `From<JfyiKaboom>`
+   = note: this error originates in the attribute macro `fatality` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
If fatality is used with edition 2024, several tests fail to compile with the error
```
error: cannot explicitly borrow within an implicitly-borrowing pattern
```

This is due to unnecessary `ref` bindings when matching by reference on fields of variants of an enum.

This PR also removes the requirement to explicitly annotate error sources, if the field name is 'source', which matches the behavior of `thiserror`.